### PR TITLE
Add the SetVideoConfig RPC reply

### DIFF
--- a/hmi_sdk/connect/src/hmi_navigation.cpp
+++ b/hmi_sdk/connect/src/hmi_navigation.cpp
@@ -27,6 +27,8 @@ void Navigation::onRequest(Json::Value &request) {
     sendResult(id, "IsReady");
   } else if (method == "Navigation.ShowConstantTBT") {
     sendResult(id, "ShowConstantTBT");
+  } else if (method == "Navigation.SetVideoConfig") {
+    sendResult(id, "SetVideoConfig");
   } else if (method == "Navigation.UpdateTurnList") {
     sendResult(id, "UpdateTurnList");
   } else if (method == "Navigation.AlertManeuver") {

--- a/testSDK/res/hmi/staticResult.json
+++ b/testSDK/res/hmi/staticResult.json
@@ -940,6 +940,10 @@
         }
     },
     "Navigation": {
+        "SetVideoConfig": {
+            "code": 0,
+            "method": "Navigation.SetVideoConfig"
+        },    
         "IsReady": {
             "available": true,
             "code": 0,


### PR DESCRIPTION
For the SDL 4.4.0 version, add the SetVideoConfig RPC reply,add the HMI RPC default reply configuration item in staticResult.json file.